### PR TITLE
701 - Creating Database Connect From Commandline rule and updating docker auth plugin rule

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_database_connect_commandline.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_database_connect_commandline.yml
@@ -1,0 +1,30 @@
+title: Database Connection from Command Line
+id: ce46fd5d-b40e-11e7-93a7-7761270db9b0
+status: stable
+description: Detects when an interactive session connects to a database via the command line interface. Licensed under DRL v1.1, original rule copyright F5, Inc.
+references:
+author: Ethan Hansen - Security Engineer, F5 Inc
+date: 2023/08/10
+logsource:
+    product: linux
+    category: process_creation
+detection:
+    selection:
+        Image|endswith: 
+          - '/mongo'
+          - '/psql'
+          - '/csql'
+          - '/redis-cli'
+          - '/mysql'
+          - '/clash'
+    filter:
+        TerminalSessionId: -1        
+    condition: selection and not filter
+fields:
+    - User
+    - Image
+    - CommandLine
+    - TerminalSessionId
+falsepositives:
+    - Legitimate access to database via the command line by an authorized user.
+level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_docker_authorization_plugin_not_used.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_docker_authorization_plugin_not_used.yml
@@ -6,9 +6,10 @@ references:
     - https://www.tenable.com/audits/items/CIS_Docker_1.13.0_L2_v1.0.0.audit:da027894f2a109151b2ea901c61d258e
 author: Ethan Hansen - Security Engineer, F5 Inc
 date: 2023/06/16
+modified: 2023/08/10
 logsource:
     product: linux
-    category: process creation
+    category: process_creation
 detection:
     selection:
         Image|endswith: '/docker'


### PR DESCRIPTION
New Rule:
- proc_creation_lnx_database_connect_commandline.yml

Updated rule, fixed syntax error:
- proc_creation_lnx_docker_authorization_plugin_not_used.yml