### PR TITLE
702: Adding in mask of -1

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_database_connect_commandline.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_database_connect_commandline.yml
@@ -18,7 +18,9 @@ detection:
           - '/mysql'
           - '/clash'
     filter:
-        TerminalSessionId: -1        
+        TerminalSessionId:
+          - -1
+          - 4294967295        
     condition: selection and not filter
 fields:
     - User


### PR DESCRIPTION
Updated rule:
- rules/linux/process_creation/proc_creation_lnx_database_connect_commandline.yml

Realized I had forgotten to add the mask of -1 in case some security tools are like AIP and make it 4294967295